### PR TITLE
GeniePath model Lack a tanh from auther paper.

### DIFF
--- a/examples/pytorch/geniepath/model.py
+++ b/examples/pytorch/geniepath/model.py
@@ -12,6 +12,7 @@ class GeniePathConv(nn.Module):
 
     def forward(self, graph, x, h, c):
         x = self.breadth_func(graph, x)
+        x = th.tanh(x)
         x = th.mean(x, dim=1)
         x, (h, c) = self.depth_func(x.unsqueeze(0), (h, c))
         x = x[0]
@@ -59,7 +60,7 @@ class GeniePathLazy(nn.Module):
         x = self.linear1(x)
         h_tmps = []
         for layer in self.breaths:
-            h_tmps.append(th.mean(layer(graph, x), dim=1))
+            h_tmps.append(th.mean(th.tanh(layer(graph, x)), dim=1))
         x = x.unsqueeze(0)
         for h_tmp, layer in zip(h_tmps, self.depths):
             in_cat = th.cat((h_tmp.unsqueeze(0), x), -1)


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
According to paper GeniePath: Graph Neural Networks with Adaptive Receptive Paths, a tanh is used after each GAT layers. Which should be considered. 
![image](https://user-images.githubusercontent.com/60515999/130018140-3b72897c-7e4d-4889-9584-317e2d877558.png)

## Checklist
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [ ] To the best of my knowledge, examples are either not affected by this change,
      or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../examples/README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
